### PR TITLE
Votecount tag

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -94,6 +94,8 @@ after_initialize do
           vote_lines.each do |line|
             # get line data
 
+            # remove parentheses containing totals
+            line.gsub!(/\(.*\)/, "")
             votee, players = line.split(":", 2)
             unless players.to_s.strip.empty?
               if(votee.downcase.eql? "not voting")


### PR DESCRIPTION
Add support for votecount tag. Allows the plugin to read a votecount made by the OP of the topic, preventing the need to process too many posts at once.